### PR TITLE
fixed setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
'description-file' caused error despite still being only 'deprecated' -> changed to 'description_file'